### PR TITLE
Insert first contributor in .all-contributorsrc

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -18,22 +18,5 @@
   },
   "linkToUsage": true,
   "skipCi": true,
-  "contributors": [
-    {
-      "login": "rdeago",
-      "name": "Riccardo De Agostini",
-      "avatar_url": "https://avatars.githubusercontent.com/u/139223?v=4",
-      "profile": "https://github.com/rdeago",
-      "contributions": [
-        "code",
-        "design",
-        "doc",
-        "ideas",
-        "maintenance",
-        "projectManagement",
-        "question",
-        "review"
-      ]
-    }
-  ]
+  "contributors": []
 }


### PR DESCRIPTION
## Proposed changes

Remove my data from .all-contributorsrc to re-add myself via bot.

## Types of changes

This pull request introduces the following types of changes:

<!-- Put an `x` in the boxes that apply. -->

- [ ] Bug fix <!-- This includes changes to tests and XML documentation as applicable. -->
- [ ] New feature <!-- This includes changes to tests and XML documentation as applicable. -->
- [ ] Test addition / update (no changes to non-test code)
- [ ] Refactor (no changes in public API syntax or semantics)
- [ ] Performance improvement (no changes in public API syntax or semantics)
- [ ] Documentation (`docs` directory) update
- [ ] Dependency addition / update
- [ ] Changes to the build scripts
- [ ] Changes to CI (workflows, bot / app configurations)
- [ ] Changes to repository files (`.gitattributes`, `.gitignore`)
- [x] Other

Just modify .all-contributorsrc

### Breaking changes

This pull request introduces breaking changes:

<!-- Put an `x` in the box that applies. -->

- [ ] Yes
- [x] No

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- **For all types of changes:**
  - [x] I have read the [Code of Conduct](https://github.com/Tenacom/.github/blob/main/CODE_OF_CONDUCT.md) and agree to be bound by it
  - [x] I have read the [Contributor Guide](https://github.com/Tenacom/.github/blob/main/CONTRIBUTING.md) and agree to follow it
- **For code changes only:**
  - [ ] The project builds on my machine, via the provided build script, _with zero warnings_
  - [ ] I have added tests that prove my feature works / my fix is effective
  - [ ] I have added / modified XML documentation according to changes in code
  - [ ] I have checked that all the links I added or modified in XML documentation point to their intended destination
- **For documentation changes (`docs` directory) only:**
  - [ ] I have built and tested documentation locally
  - [ ] I have checked that all the links I added or modified point to their intended destination
